### PR TITLE
Migrate to `set` helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ import Store from '../store';
 
 const Component = () => {
   // read from `state`, mutate `store`
-  const [state, store] = useStore(Store);
+  const store = useStore(Store);
   const subtract = () => store.count--;
   const add = () => store.count++;
 
   return (
     <div>
       <button onClick={subtract}>-</button>
-      <div>{state.count}</div>
+      <div>{store.count}</div>
       <button onClick={add}>+</button>
     </div>
   );
@@ -61,7 +61,7 @@ const Component = () => {
 <template>
   <div>
     <button @click="subtract">-</button>
-    <div>{{ state.count }}</div>
+    <div>{{ store.count }}</div>
     <button @click="add">+</button>
   </div>
 </template>
@@ -73,12 +73,12 @@ import Store from '../store';
 
 export default defineComponent({
   setup() {
-    const [state, store] = useStore(Store);
+    const store = useStore(Store);
     const subtract = () => store.count--;
     const add = () => store.count++;
 
     return {
-      state,
+      store,
       add,
       subtract,
     };
@@ -101,8 +101,8 @@ const add = () => store.count++;
 
 document.querySelector('button#add').addEventListener('click', add);
 document.querySelector('button#subtract').addEventListener('click', subtract);
-subscribe((s) => {
-  document.querySelector('div#count').innerHTML = `${s.count}`;
+subscribe(() => {
+  document.querySelector('div#count').innerHTML = `${store.count}`;
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ import { useStore } from '@exo-store/preact';
 import Store from '../store';
 
 const Component = () => {
-  // read from `state`, mutate `store`
   const store = useStore(Store);
   const subtract = () => store.count--;
   const add = () => store.count++;
@@ -104,6 +103,39 @@ document.querySelector('button#subtract').addEventListener('click', subtract);
 subscribe(() => {
   document.querySelector('div#count').innerHTML = `${store.count}`;
 });
+```
+
+## Reactivity
+
+Stores are fully reactive, even when destructuring or using a [selector](#selectors). However, because primitive (non-object) values in JavaScript are updated by assignment rather than reference, we must use a special `set` helper for primitives.
+
+```tsx
+import { useStore, set } from '@exo-store/preact';
+import Store from '../store';
+
+const Component = () => {
+  // Because we've selected just `count` (a number), assigning a new value
+  // won't update the store. We should use the `set` helper instead!
+  const count = useStore(Store, s => s.count);
+  const subtract = () => set(count, value => value -= 1);
+  const add = () => set(count, value => value += 1);
+
+  return (
+    <div>
+      <button onClick={subtract}>-</button>
+      <div>{count}</div>
+      <button onClick={add}>+</button>
+    </div>
+  );
+};
+```
+
+Here is the signature of `set`.
+
+```ts
+/** Update a primitive value (from a store) in a reactive manner */
+function set<T extends string|number|boolean>(value: T, newValue: T): void;
+function set<T extends string|number|boolean>(value: T, setter: (currentValue: T) => T): void;
 ```
 
 ## Utilities

--- a/examples/kitchen-sink/package.json
+++ b/examples/kitchen-sink/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "@exo-store/preact": "0.0.1",
     "@exo-store/vue": "0.0.1",
-    "@exo-store/worker": "0.0.1",
     "lit-element": "^2.4.0",
     "preact": "^10.5.13",
     "vue": "^3.0.11"

--- a/examples/kitchen-sink/public/index.css
+++ b/examples/kitchen-sink/public/index.css
@@ -1,3 +1,12 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+}
+
+:root {
+  font-family: system-ui;
+}
+
 body {
   width: 100vw;
   height: 100vh;
@@ -8,10 +17,42 @@ body {
 main {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 2em;
+  gap: 1em;
 }
 
 .app {
   border: 1px solid black;
   padding: 32px;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+}
+
+.value {
+  padding: 1em;
+  border: 1px solid #eee;
+  transition: box-shadow 150ms ease-in;
+}
+
+.flash {
+  border-color: transparent;
+  box-shadow: inset 0 0 0 2px rgba(255, 0, 255, 60%);
+  transition: box-shadow 200ms ease-out;
+}
+
+#vanilla {
+  grid-column: 1 / -1;
+}
+
+pre {
+  font-size: 0.8em;
+  font-family: Consolas, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", Monaco, "Courier New", Courier, monospace;
+}
+
+#store {
+  background: #eee;
+  border-radius: 4px;
+  margin: 0 -1.25em -1em;
+  padding: 1em 1.25em;
 }

--- a/examples/kitchen-sink/public/index.html
+++ b/examples/kitchen-sink/public/index.html
@@ -13,6 +13,11 @@
     <main>
       <div class="app" id="preact"></div>
       <div class="app" id="vue"></div>
+      <div class="app" id="vanilla">
+        <h3>Hello from the plain old DOM!</h3>
+        <pre id="total"></pre>
+        <pre id="store"></pre>
+      </div>
     </main>
 
     <script type="module" src="/dist/index.js"></script>

--- a/examples/kitchen-sink/src/components/App.preact.tsx
+++ b/examples/kitchen-sink/src/components/App.preact.tsx
@@ -1,18 +1,43 @@
-import { FunctionalComponent, h } from 'preact';
+import { FunctionalComponent, h, Fragment } from 'preact';
+import { memo } from 'preact/compat';
+import { set } from '@exo-store/core';
 import { useStore } from '@exo-store/preact';
 import MyStore from '../store';
+import { useEffect, useRef } from 'preact/hooks';
+
+const useFlash = (value: any) => {
+  const el = useRef<any>();
+  useEffect(() => {
+    const div = el.current;
+    if (!div) return;
+    div.classList.add('flash');
+    setTimeout(() => {
+      div.classList.remove('flash');
+    }, 500);
+  }, [el, value])
+  return el;
+}
+
+const Selected = memo(() => {
+  const count = useStore(MyStore, v => v.deeply.nested.value);
+  const el = useFlash(count);
+  return <pre class="value" ref={el} dangerouslySetInnerHTML={{ __html: `{ deeply: { nested: { value: ${count} }}}` }} />
+});
 
 const App: FunctionalComponent = () => {
-  const [state, store] = useStore(MyStore, (v) => v.preact);
-  const add = () => store.preact++;
+  const count = useStore(MyStore, v => v.preact);
+  const add = () => set(count, v => v + 1);
+  const el = useFlash(count);
 
   return (
-    <div>
+    <>
       <h3>Hello from Preact!</h3>
-      <pre>{JSON.stringify(state, null, 2)}</pre>
+      <pre ref={el} class="value" dangerouslySetInnerHTML={{ __html: 'preact: ' + count }} />
+
+      <Selected />
 
       <button onClick={add}>+</button>
-    </div>
+    </>
   );
 };
 

--- a/examples/kitchen-sink/src/components/App.ts
+++ b/examples/kitchen-sink/src/components/App.ts
@@ -1,0 +1,33 @@
+import { $ } from '@exo-store/core';
+import store from '../store';
+
+const { subscribe, ready } = store[$]
+const root = document.querySelector('#total')!;
+const pre = document.querySelector('#store')!;
+
+const updatePre = () => {
+    pre.textContent = JSON.stringify(store, null, 2);
+}
+
+export default async () => {
+    // Print the fallback store state while store initializes
+    root.textContent = [`total: ${store.total}`, `ready: false`].join('\n');
+    updatePre();
+
+    // Wait for the store to asynchronously initialize
+    await ready();
+    
+    // Print the initialized store state
+    root.textContent = [`total: ${store.total}`, `ready: true`].join('\n');
+    updatePre();
+    
+    // Only called for changes *after* the store has been initialized
+    subscribe(store => {
+        console.log('Initialized');
+        root.textContent = [
+            `total: ${store.total}`,
+            `ready: true`
+        ].join('\n');
+        updatePre();
+    })
+}

--- a/examples/kitchen-sink/src/components/App.vue
+++ b/examples/kitchen-sink/src/components/App.vue
@@ -1,24 +1,37 @@
 <template>
-    <h3>Shared</h3>
-    <pre v-html="JSON.stringify(state, null, 2)" />
+    <h3>Hello from Vue!</h3>
+    <pre ref="el" class="value" v-html="'vue: ' + count" />
     
     <button @click="add">+</button>
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { defineComponent, ref, watch, unref } from 'vue'
+import { set } from '@exo-store/core';
 import { useStore } from '@exo-store/vue';
 import MyStore from '../store';
 
 export default defineComponent({
     setup() {
-        const [state, store] = useStore(MyStore);
-        const add = () => store.vue++;
+        const el = ref();
+        const count = useStore(MyStore, v => v.vue);
+        const add = () => set(count, v => v + 1);
+
+        watch([el, count], () => {
+            const div = unref(el);
+            console.log(div);
+            if (!div) return;
+            div.classList.add('flash');
+            setTimeout(() => div.classList.remove('flash'), 200);
+        })
+
 
         return {
-            state,
+            el,
+            count,
             add
         }
     }
 })
 </script>
+

--- a/examples/kitchen-sink/src/index.ts
+++ b/examples/kitchen-sink/src/index.ts
@@ -1,5 +1,7 @@
 import renderPreact from './render/preact';
 import renderVue from './render/vue';
+import renderVanilla from './render/vanilla';
 
 renderPreact();
 renderVue();
+renderVanilla();

--- a/examples/kitchen-sink/src/render/vanilla.ts
+++ b/examples/kitchen-sink/src/render/vanilla.ts
@@ -1,0 +1,4 @@
+import App from '../components/App';
+export default () => {
+    App();
+}

--- a/examples/kitchen-sink/src/store.ts
+++ b/examples/kitchen-sink/src/store.ts
@@ -5,15 +5,20 @@ const initialState = {
   preact: 0,
   vue: 0,
   total: 0,
+  deeply: { nested: { value: 0 }}
 };
 
 const sleep = (ms: number) => new Promise(res => setTimeout(res, ms));
 const store = createStore(async () => {
-  await sleep(1000);
-  return {...initialState, status: 'done', preact: 10 }
+  await sleep(500 + Math.random() * 2000);
+  return { ...initialState, status: 'done', preact: 10 }
 }, initialState);
 const { compute } = store[$];
 
 store.total = compute((s) => s.preact + s.vue);
+
+setInterval(() => {
+  store.deeply.nested.value++;
+}, 5000)
 
 export default store;

--- a/examples/kitchen-sink/src/store.ts
+++ b/examples/kitchen-sink/src/store.ts
@@ -15,7 +15,7 @@ const store = createStore(async () => {
 }, initialState);
 const { compute } = store[$];
 
-store.total = compute((s) => s.preact + s.vue);
+store.total = compute((s) => s.preact + s.vue + s.deeply.nested.value);
 
 setInterval(() => {
   store.deeply.nested.value++;

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,5 +1,3 @@
-import { dset } from 'dset';
-
 interface StoreChange {
   path: string;
   oldValue?: any;

--- a/packages/preact/index.ts
+++ b/packages/preact/index.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'preact/hooks';
 import { $, Store, WithoutStoreMarker } from '@exo-store/core';
+export { set } from '@exo-store/core';
 
 export function useStore<T extends Store<any>>(
   store: T,

--- a/packages/preact/index.ts
+++ b/packages/preact/index.ts
@@ -1,16 +1,16 @@
 import { useState, useEffect } from 'preact/hooks';
-import { $, freeze, Store, WithoutStoreMarker } from '@exo-store/core';
+import { $, Store, WithoutStoreMarker } from '@exo-store/core';
 
 export function useStore<T extends Store<any>>(
   store: T,
-): [Readonly<WithoutStoreMarker<T>>, WithoutStoreMarker<T>];
+): WithoutStoreMarker<T>;
 export function useStore<
   T extends Store<any>,
   Selector extends (value: WithoutStoreMarker<T>) => any
 >(
   store: T,
   selector: Selector,
-): [Readonly<ReturnType<Selector>>, WithoutStoreMarker<T>];
+): ReturnType<Selector>;
 export function useStore<
   T extends Store<any>,
   Selector extends (value: WithoutStoreMarker<T>) => any
@@ -19,7 +19,7 @@ export function useStore<
   const [_, forceUpdate] = useState({});
 
   const onChange = (v: typeof value) => {
-    value = freeze(v);
+    value = v;
     forceUpdate({});
   };
 
@@ -32,7 +32,7 @@ export function useStore<
     }
 
     return (store as Store<any>)[$].subscribe(onChange);
-  }, [store]);
+  }, []);
 
-  return [value, store];
+  return value;
 }

--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -1,16 +1,17 @@
 import { useState, useEffect } from 'react';
-import { $, freeze, Store, WithoutStoreMarker } from '@exo-store/core';
+import { $, Store, WithoutStoreMarker } from '@exo-store/core';
+export { set } from '@exo-store/core';
 
 export function useStore<T extends Store<any>>(
   store: T,
-): [Readonly<WithoutStoreMarker<T>>, WithoutStoreMarker<T>];
+): WithoutStoreMarker<T>;
 export function useStore<
   T extends Store<any>,
   Selector extends (value: WithoutStoreMarker<T>) => any
 >(
   store: T,
   selector: Selector,
-): [Readonly<ReturnType<Selector>>, WithoutStoreMarker<T>];
+): ReturnType<Selector>;
 export function useStore<
   T extends Store<any>,
   Selector extends (value: WithoutStoreMarker<T>) => any
@@ -19,7 +20,7 @@ export function useStore<
   const [_, forceUpdate] = useState({});
 
   const onChange = (v: typeof value) => {
-    value = freeze(v);
+    value = v;
     forceUpdate({});
   };
 
@@ -32,7 +33,7 @@ export function useStore<
     }
 
     return (store as Store<any>)[$].subscribe(onChange);
-  }, [store]);
+  }, []);
 
-  return [value, store];
+  return value;
 }

--- a/packages/vue/index.ts
+++ b/packages/vue/index.ts
@@ -1,5 +1,6 @@
 import { onUnmounted, ref, getCurrentInstance, isRef, Ref } from 'vue';
 import { $, Store, WithoutStoreMarker } from '@exo-store/core';
+export { set } from '@exo-store/core';
 
 const autoUnref = (value: Ref<any>) => {
   return new Proxy(value, {

--- a/packages/vue/index.ts
+++ b/packages/vue/index.ts
@@ -1,27 +1,42 @@
-import { onUnmounted, ref } from 'vue';
-import { $, freeze, Store, WithoutStoreMarker } from '@exo-store/core';
+import { onUnmounted, ref, getCurrentInstance, isRef, Ref } from 'vue';
+import { $, Store, WithoutStoreMarker } from '@exo-store/core';
+
+const autoUnref = (value: Ref<any>) => {
+  return new Proxy(value, {
+    get(target, prop, receiver) {
+      let _value = Reflect.get(target, prop, receiver);
+      if (typeof _value === 'undefined' && isRef(target)) {
+        _value = Reflect.get((target as Ref<any>).value, prop, receiver);
+      }
+      return _value;
+    }
+  })
+}
 
 export function useStore<T extends Store<any>>(
   store: T,
-): [Readonly<WithoutStoreMarker<T>>, WithoutStoreMarker<T>];
+): WithoutStoreMarker<T>;
 export function useStore<
   T extends Store<any>,
   Selector extends (value: WithoutStoreMarker<T>) => any
 >(
   store: T,
   select: Selector,
-): [Readonly<ReturnType<Selector>>, WithoutStoreMarker<T>];
+): ReturnType<Selector>;
 export function useStore<
   T extends Store<any>,
   Selector extends (value: WithoutStoreMarker<T>) => any
 >(
   store: T,
   select?: Selector,
-): [Readonly<WithoutStoreMarker<T>>, WithoutStoreMarker<T>] {
-  let value = ref(select ? select(store) : store);
+) {
+  const instance = getCurrentInstance();
+  let value = autoUnref(ref(select ? select(store) : store));
 
   const onChange = (v: typeof value) => {
-    value.value = freeze(v);
+    if (isRef(value)) value.value = v;
+    else value = v;
+    instance?.update();
   };
 
   let unsubscribe = () => {};
@@ -36,5 +51,5 @@ export function useStore<
 
   onUnmounted(unsubscribe);
 
-  return [value, store];
+  return value;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,11 +152,6 @@ colorette@^1.2.2:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
-comlink@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/comlink/-/comlink-4.3.0.tgz#80b3366baccd87897dab3638ebfcfae28b2f87c7"
-  integrity sha512-mu4KKKNuW8TvkfpW/H88HBPeILubBS6T94BdD1VWBXNXfiyqVtwUCVNO1GeNOBTsIswzsMjWlycYr+77F5b84g==
-
 consolidate@^0.16.0:
   version "0.16.0"
   resolved "https://registry.yarnpkg.com/consolidate/-/consolidate-0.16.0.tgz#a11864768930f2f19431660a65906668f5fbdc16"


### PR DESCRIPTION
Just return the mutable `store` rather than returning `[state, store]`. Exposes a new `set` helper for setting primitives.